### PR TITLE
Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Accounts Manager
+
+Accounts Manager is a simple REST API written in Go for managing user accounts. It uses the Gin web framework and GORM with a SQLite database. Authentication is handled with JSON Web Tokens (JWT).
+
+## Features
+
+- Create, read, update and delete users
+- JWT‑based authentication with access and refresh tokens
+- SQLite database for storage
+
+## Requirements
+
+- Go 1.24+
+
+## Getting Started
+
+1. Install dependencies and run the application:
+
+```bash
+go run main.go
+```
+
+2. The server will start on `http://localhost:8080` and create a local `accounts.db` file if it does not exist.
+
+## API
+
+### Public Endpoints
+
+- `POST /users` &ndash; create a new user.
+- `POST /login` &ndash; authenticate and obtain an access and refresh token.
+
+### Protected Endpoints
+
+These require an `Authorization: Bearer <token>` header with a valid access token.
+
+- `GET /users/:id` &ndash; retrieve a specific user.
+- `PUT /users/:id` &ndash; update a user.
+- `DELETE /users/:id` &ndash; remove a user.
+- `GET /users/` &ndash; list all users.
+
+### Refresh Token
+
+`controllers/userController.go` contains a `RefreshToken` handler for issuing a new access token. A route for it is not currently configured but can be added as needed.
+
+## Configuration
+
+For simplicity the JWT signing key and database path are hard coded. In a production setting you should load configuration from environment variables or a configuration file.
+
+## Next Steps
+
+- Protect sensitive configuration values
+- Add tests for handlers and middleware
+- Document all endpoints in detail

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ These require an `Authorization: Bearer <token>` header with a valid access toke
 
 ## Configuration
 
-For simplicity the JWT signing key and database path are hard coded. In a production setting you should load configuration from environment variables or a configuration file.
+For simplicity the JWT signing key and database path are hardcoded. In a production setting you should load configuration from environment variables or a configuration file.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- document the Accounts Manager service in a new README

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f404ef5348333be69f0b5b2524703

## Resumen por Sourcery

Añade un archivo README para documentar el servicio de la API REST del Administrador de Cuentas.

Documentación:
- Incluye la descripción del servicio, las características, los requisitos y las instrucciones de configuración
- Detalla los endpoints de la API pública y protegida y la nota del token de refresco
- Describe la configuración por defecto y los próximos pasos para las mejoras

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a README file to document the Accounts Manager REST API service.

Documentation:
- Include service description, features, requirements, and setup instructions
- Detail public and protected API endpoints and refresh token note
- Outline configuration defaults and next steps for improvements

</details>